### PR TITLE
Allow versions of mocha that are greater than 1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "reporter"
   ],
   "peerDependencies": {
-    "mocha": "^1.7.0"
+    "mocha": ">=1.7.0"
   },
   "devDependencies": {
     "mocha": "^1.7.0",


### PR DESCRIPTION
Limiting the peer dependency to 1.7 only is problematic.
